### PR TITLE
comply to new validation requirements of node 10 for custom loaders

### DIFF
--- a/loader.mjs
+++ b/loader.mjs
@@ -24,7 +24,7 @@ function readFile(path) {
 }
 
 export async function dynamicInstantiate(url) {
-  const buffer = readFile(url);
+  const buffer = readFile((new URL(url)).pathname);
   const module = new WebAssembly.Module(buffer);
 
   const wasmExports = [];
@@ -86,7 +86,7 @@ export function resolve(specifier, base, defaultResolver) {
 
   if (ext === ".wasm") {
     return {
-      url: specifier,
+      url: path.join(path.dirname(base), specifier),
       format: 'dynamic'
     };
   }


### PR DESCRIPTION
Guy Bedford explained to me that they had to introduce a validation in order to avoid collisions. Otherwise you could have `x/index.js` and `x/y/index.js` where `index.js` is loaded as `index.js` being stored in the registry resulting in a collision.

The validation can be found here: https://github.com/nodejs/node/commit/1bf42f4777bfc7ce61873dbd17660b9e265357e9#diff-6dda3ef5f860111452d324058e12a738R82
