### PR TITLE
use builtin WebAssembly interface instead of AST parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
     "url": "https://github.com/wasm-tool/node-loader/issues"
   },
   "homepage": "https://github.com/wasm-tool/node-loader#readme",
-  "dependencies": {
-    "@webassemblyjs/ast": "^1.5.12",
-    "@webassemblyjs/wasm-parser": "^1.5.12"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
out of curiosity, how do you plan to interoperate with the future WASM modules being worked on by the web assembly working group? i was going to add wasm loading to node core but ended up cancelling the feature because of that (https://github.com/nodejs/node/pull/18972)